### PR TITLE
Changes for 64-bit support in Xcode 6 for iOS 8.x

### DIFF
--- a/PublicAutomation.xcodeproj/project.pbxproj
+++ b/PublicAutomation.xcodeproj/project.pbxproj
@@ -217,9 +217,11 @@
 		C194254715D838BD004FC314 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				DSTROOT = /tmp/PublicAutomation.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PublicAutomation/PublicAutomation-Prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -229,9 +231,11 @@
 		C194254815D838BD004FC314 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				DSTROOT = /tmp/PublicAutomation.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PublicAutomation/PublicAutomation-Prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
This sub-module change is required for 64-bit build support in TestingWithFrank/Frank. I will submit another pull request there that completes the 64-bit build support work done by squidpunch and submitted as pull request #37 on TestingWithFrank/Frank.